### PR TITLE
Kid circle styling

### DIFF
--- a/App/components/KidCircleCard/index.js
+++ b/App/components/KidCircleCard/index.js
@@ -1,0 +1,98 @@
+import React from "react";
+import {
+  View,
+  Text,
+  Dimensions,
+  Image,
+  TouchableWithoutFeedback,
+} from "react-native";
+import styles from "@styles/styles";
+import colors from "@assets/colors";
+import fonts from "@assets/fonts";
+import { useNavigation } from "@react-navigation/native";
+
+export default function KidCircleCard(props) {
+  const navigation = useNavigation();
+  const { id, kidName, kidImage } = props;
+  return (
+    <View
+      style={{
+        marginBottom: "20%",
+      }}
+    >
+      <TouchableWithoutFeedback
+        onPress={() =>
+          /*This should bring user to the correct Recommended page, for now passing the kids name in param*/ navigation.navigate(
+            "Recommended",
+            { kidName }
+          )
+        }
+      >
+        <Text
+          style={[
+            styles.cardText,
+            {
+              color: colors.dkPink,
+              fontFamily: fonts.semiBold,
+              paddingBottom: 15,
+            },
+          ]}
+        >
+          {kidName}
+        </Text>
+      </TouchableWithoutFeedback>
+      <TouchableWithoutFeedback
+        onPress={() =>
+          /*This should bring user to the correct Recommended page, for now passing the kids name in param*/ navigation.navigate(
+            "Recommended",
+            { kidName }
+          )
+        }
+      >
+        <View
+          style={{
+            backgroundColor: "white",
+            width: "100%",
+            height: Dimensions.get("window").width * 0.5,
+            alignSelf: "center",
+            justifyContent: "space-evenly",
+            shadowColor: "black",
+            shadowOffset: { width: 0, height: 0 },
+            shadowOpacity: 0.05,
+            shadowRadius: 5,
+            borderRadius: 100,
+          }}
+        >
+          <Image
+            style={[
+              styles.cardImage,
+              { width: "100%", height: Dimensions.get("window").width * 0.3 },
+            ]}
+            source={kidImage}
+          />
+        </View>
+      </TouchableWithoutFeedback>
+      {/* 
+      <Image
+        style={[
+          styles.cardImage,
+          {
+            backgroundColor: "blue",
+            width: "90%",
+            height: "90%",
+            borderRadius: 100,
+          },
+        ]}
+        source={kidImage}
+      />
+      <Text
+        style={[
+          styles.cardTitle,
+          { color: colors.dkPink, backgroundColor: "yellow" },
+        ]}
+      >
+        {kidName}
+      </Text> */}
+    </View>
+  );
+}

--- a/App/components/NavButtons/index.js
+++ b/App/components/NavButtons/index.js
@@ -8,6 +8,7 @@ import { useNavigation } from "@react-navigation/native";
 export default function NavButtons(props) {
   const navigation = useNavigation();
   const { screen } = props;
+  console.log("screen", screen);
 
   function today() {
     if (screen === "Recommended") {
@@ -22,6 +23,8 @@ export default function NavButtons(props) {
           </View>
         </TouchableWithoutFeedback>
       );
+    } else if (screen === "Single") {
+      return null;
     } else {
       return (
         <TouchableWithoutFeedback
@@ -49,6 +52,8 @@ export default function NavButtons(props) {
           </View>
         </TouchableWithoutFeedback>
       );
+    } else if (screen === "Single") {
+      return null;
     } else {
       return (
         <TouchableWithoutFeedback
@@ -68,6 +73,17 @@ export default function NavButtons(props) {
       return (
         <TouchableWithoutFeedback>
           <View style={styles.navActiveBtContainer}>
+            <Image style={styles.navBtImage} source={images.monkey} />
+            <Text style={styles.bottomText}>Account</Text>
+          </View>
+        </TouchableWithoutFeedback>
+      );
+    } else if (screen === "Single") {
+      return (
+        <TouchableWithoutFeedback
+          onPress={() => navigation.navigate("Settings", "single")}
+        >
+          <View style={styles.navBtContainer}>
             <Image style={styles.navBtImage} source={images.monkey} />
             <Text style={styles.bottomText}>Account</Text>
           </View>

--- a/App/components/NavHome/index.js
+++ b/App/components/NavHome/index.js
@@ -24,7 +24,7 @@ export default function NavHome() {
             width: 20,
             height: 20,
             marginTop: 57,
-            marginRight: 50,
+            marginRight: 80,
           }}
         ></View>
       </TouchableWithoutFeedback>
@@ -32,7 +32,7 @@ export default function NavHome() {
         onPress={() => navigation.navigate("Recommended")}
       >
         <Image
-          style={[styles.peekabondLogo, { marginRight: 70 }]}
+          style={[styles.peekabondLogo, { marginRight: 90 }]}
           source={images.peekabondLogo}
         />
       </TouchableWithoutFeedback>

--- a/App/navigation/StackNavigator.js
+++ b/App/navigation/StackNavigator.js
@@ -22,7 +22,7 @@ export default function authNavigator({ route }) {
   return (
     <NavigationContainer>
       <Stack.Navigator
-        initialRouteName="Settings"
+        initialRouteName="KidCircles"
         screenOptions={{ headerShown: false }}
       >
         <Stack.Screen name="KidCircles" component={KidCircles} />

--- a/App/screens/KidCircles/index.js
+++ b/App/screens/KidCircles/index.js
@@ -1,9 +1,20 @@
 import React from "react";
-import { View, Text, TouchableWithoutFeedback, Image } from "react-native";
+import {
+  View,
+  Text,
+  TouchableWithoutFeedback,
+  Image,
+  FlatList,
+  Dimensions,
+} from "react-native";
 import styles from "@styles/styles"; //have to changeit to @styles/styles
 import style from "./style";
 import images from "@assets/images";
 import NavButtons from "../../components/NavButtons";
+import KidCircleCard from "../../components/KidCircleCard";
+import colors from "@assets/colors";
+import fonts from "@assets/fonts";
+import adjust from "../../styles/adjust";
 
 export default function KidCircles({ navigation }) {
   const circles = [
@@ -31,28 +42,172 @@ export default function KidCircles({ navigation }) {
         justifyContent: "space-evenly",
       }}
     >
-      <Image style={styles.peekabondLogo} source={images.peekabondLogo} />
+      <Image
+        style={[styles.peekabondLogo, { marginBottom: -120, width: "30%" }]}
+        source={images.peekabondLogo}
+      />
       <Text style={styles.title} adjustsFontSizeToFit={true} numberOfLines={1}>
-        Welcome back, [firstNameOfuser]!
+        Welcome back, [firstNameOfUser]!
       </Text>
 
-      <View style={[style.spacing]}></View>
-
-      <TouchableWithoutFeedback
-        onPress={() => navigation.navigate("CreateKidCircle")}
-      >
-        <View style={[styles.ltPurple, styles.button]}>
-          <Text style={[styles.button]}>Create Family</Text>
-        </View>
-      </TouchableWithoutFeedback>
-
-      <TouchableWithoutFeedback
-        onPress={() => navigation.navigate("JoinKidCircle")}
-      >
-        <View style={[styles.pink, styles.button]}>
-          <Text style={[styles.button]}>Join Family</Text>
-        </View>
-      </TouchableWithoutFeedback>
+      <FlatList
+        contentContainerStyle={{
+          alignSelf: "center",
+          width: "50%",
+          paddingTop: 30,
+        }}
+        data={circles}
+        numColumns={1}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => {
+          return (
+            <TouchableWithoutFeedback>
+              <KidCircleCard
+                id={item.id}
+                kidImage={item.kidImage}
+                kidName={item.kidName}
+              />
+            </TouchableWithoutFeedback>
+          );
+        }}
+        ListFooterComponent={
+          <View style={{ flexDirection: "row", justifyContent: "center" }}>
+            <View
+              style={{
+                width: "50%",
+                height: Dimensions.get("window").width * 0.25,
+                marginHorizontal: "10%",
+                marginBottom: 150,
+              }}
+            >
+              <TouchableWithoutFeedback
+                onPress={() => navigation.navigate("JoinKidCircle")}
+              >
+                <View>
+                  <Text
+                    style={[
+                      styles.cardText,
+                      {
+                        color: colors.dkPink,
+                        fontFamily: fonts.semiBold,
+                      },
+                    ]}
+                  >
+                    Join Circle
+                  </Text>
+                  <Text
+                    style={[
+                      styles.cardText,
+                      {
+                        color: colors.purple,
+                        fontFamily: fonts.semiBold,
+                        paddingBottom: 15,
+                        fontSize: adjust(10),
+                      },
+                    ]}
+                  >
+                    (Access Code)
+                  </Text>
+                </View>
+              </TouchableWithoutFeedback>
+              <TouchableWithoutFeedback
+                onPress={() => navigation.navigate("JoinKidCircle")}
+              >
+                <View
+                  style={{
+                    backgroundColor: "white",
+                    width: "100%",
+                    height: "100%",
+                    alignSelf: "center",
+                    justifyContent: "space-evenly",
+                    shadowColor: "black",
+                    shadowOffset: { width: 0, height: 0 },
+                    shadowOpacity: 0.05,
+                    shadowRadius: 5,
+                    borderRadius: 100,
+                  }}
+                >
+                  <Text
+                    style={[
+                      styles.cardText,
+                      {
+                        color: colors.purple,
+                        fontFamily: fonts.bold,
+                        fontSize: adjust(50),
+                      },
+                    ]}
+                  >
+                    #
+                  </Text>
+                </View>
+              </TouchableWithoutFeedback>
+            </View>
+            <View
+              style={{
+                width: "50%",
+                height: Dimensions.get("window").width * 0.25,
+                marginHorizontal: "10%",
+              }}
+            >
+              <TouchableWithoutFeedback
+                onPress={() => navigation.navigate("CreateKidCircle")}
+              >
+                <Text
+                  style={[
+                    styles.cardText,
+                    {
+                      color: colors.dkPink,
+                      fontFamily: fonts.semiBold,
+                      paddingBottom: 15,
+                    },
+                  ]}
+                >
+                  Create New Circle
+                </Text>
+              </TouchableWithoutFeedback>
+              <TouchableWithoutFeedback
+                onPress={() => navigation.navigate("CreateKidCircle")}
+              >
+                <View
+                  style={{
+                    backgroundColor: "white",
+                    width: "100%",
+                    height: "100%",
+                    alignSelf: "center",
+                    justifyContent: "space-evenly",
+                    shadowColor: "black",
+                    shadowOffset: { width: 0, height: 0 },
+                    shadowOpacity: 0.05,
+                    shadowRadius: 5,
+                    borderRadius: 100,
+                  }}
+                >
+                  <View
+                    style={{
+                      alignSelf: "center",
+                      width: "50%",
+                      backgroundColor: colors.purple,
+                      height: "10%",
+                      borderRadius: 25,
+                    }}
+                  ></View>
+                  <View
+                    style={{
+                      top: "25%",
+                      alignSelf: "center",
+                      position: "absolute",
+                      width: "10%",
+                      backgroundColor: colors.purple,
+                      height: "50%",
+                      borderRadius: 25,
+                    }}
+                  ></View>
+                </View>
+              </TouchableWithoutFeedback>
+            </View>
+          </View>
+        }
+      />
       <NavButtons screen="Single" />
     </View>
   );

--- a/App/screens/KidCircles/index.js
+++ b/App/screens/KidCircles/index.js
@@ -3,8 +3,27 @@ import { View, Text, TouchableWithoutFeedback, Image } from "react-native";
 import styles from "@styles/styles"; //have to changeit to @styles/styles
 import style from "./style";
 import images from "@assets/images";
+import NavButtons from "../../components/NavButtons";
 
 export default function KidCircles({ navigation }) {
+  const circles = [
+    {
+      id: 1,
+      kidImage: images.monkey,
+      kidName: "Atieh",
+    },
+    {
+      id: 2,
+      kidImage: images.monkey,
+      kidName: "Weilong",
+    },
+    {
+      id: 3,
+      kidImage: images.monkey,
+      kidName: "Nazneen",
+    },
+  ];
+
   return (
     <View
       style={{
@@ -13,8 +32,8 @@ export default function KidCircles({ navigation }) {
       }}
     >
       <Image style={styles.peekabondLogo} source={images.peekabondLogo} />
-      <Text style={[style.text]}>
-        Welcome! Do you want to create a family or Join an existing family
+      <Text style={styles.title} adjustsFontSizeToFit={true} numberOfLines={1}>
+        Welcome back, [firstNameOfuser]!
       </Text>
 
       <View style={[style.spacing]}></View>
@@ -34,6 +53,7 @@ export default function KidCircles({ navigation }) {
           <Text style={[styles.button]}>Join Family</Text>
         </View>
       </TouchableWithoutFeedback>
+      <NavButtons screen="Single" />
     </View>
   );
 }

--- a/App/screens/KidCircles/index.js
+++ b/App/screens/KidCircles/index.js
@@ -1,13 +1,20 @@
 import React from "react";
-import { View, Text, TouchableWithoutFeedback } from "react-native";
-import styles from "../../styles" //have to changeit to @styles/styles
+import { View, Text, TouchableWithoutFeedback, Image } from "react-native";
+import styles from "@styles/styles"; //have to changeit to @styles/styles
 import style from "./style";
+import images from "@assets/images";
 
 export default function KidCircles({ navigation }) {
   return (
-    <View style={[ styles.fontFamily, style.container, style.spacing ]}>
+    <View
+      style={{
+        flex: 1,
+        justifyContent: "space-evenly",
+      }}
+    >
+      <Image style={styles.peekabondLogo} source={images.peekabondLogo} />
       <Text style={[style.text]}>
-      Welcome! Do you want to create a family or Join an existing family
+        Welcome! Do you want to create a family or Join an existing family
       </Text>
 
       <View style={[style.spacing]}></View>
@@ -16,9 +23,7 @@ export default function KidCircles({ navigation }) {
         onPress={() => navigation.navigate("CreateKidCircle")}
       >
         <View style={[styles.ltPurple, styles.button]}>
-          <Text style={[styles.button]}>
-            Create Family
-          </Text>
+          <Text style={[styles.button]}>Create Family</Text>
         </View>
       </TouchableWithoutFeedback>
 
@@ -26,9 +31,7 @@ export default function KidCircles({ navigation }) {
         onPress={() => navigation.navigate("JoinKidCircle")}
       >
         <View style={[styles.pink, styles.button]}>
-          <Text style={[styles.button]}>
-            Join Family
-          </Text>
+          <Text style={[styles.button]}>Join Family</Text>
         </View>
       </TouchableWithoutFeedback>
     </View>

--- a/App/screens/Settings/index.js
+++ b/App/screens/Settings/index.js
@@ -1,4 +1,3 @@
-
 import React, { useState, useContext } from "react";
 import { AuthContext } from "../../context/Auth";
 import {
@@ -20,6 +19,7 @@ import fonts from "@assets/fonts";
 import adjust from "../../styles/adjust";
 
 export default function Settings({ route, navigation }) {
+  const single = route.params;
   const { signOut } = useContext(AuthContext);
   const profileInfo = {
     firstName: "Diégo",
@@ -39,8 +39,6 @@ export default function Settings({ route, navigation }) {
   };
 
   const [variables, setVariables] = useState(initState);
-  const something = route.params;
-  console.log("is there something", something);
   const [changeProfilePicture, setChangeProfilePicture] = useState(false);
   const [changeInfo, setChangeInfo] = useState(false);
   const [successMessage, setSuccessMessage] = useState({ text: "", color: "" });
@@ -351,7 +349,7 @@ export default function Settings({ route, navigation }) {
         </TouchableWithoutFeedback>
       )}
 
-{!changeInfo && (
+      {!changeInfo && (
         <TouchableWithoutFeedback onPress={() => signOut()}>
           <Text
             style={[
@@ -360,7 +358,7 @@ export default function Settings({ route, navigation }) {
                 color: colors.ltPurple,
                 fontFamily: fonts.semiBold,
                 marginTop: 20,
-                marginBottom: 20,
+                marginBottom: !single ? 20 : "20%",
               },
             ]}
           >
@@ -370,9 +368,8 @@ export default function Settings({ route, navigation }) {
       )}
 
       {showMessage()}
-      <NavButtons screen="Settings" />
+      {!single && <NavButtons screen="Settings" />}
       {changeProfilePicture && <ChangeProfilePicture hide={hideOptions} />}
-
     </View>
   );
 }

--- a/App/screens/UploadKidProfile/index.js
+++ b/App/screens/UploadKidProfile/index.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import * as firebase from "firebase";
 import * as ImagePicker from "expo-image-picker";
 
-
 import {
   View,
   Button,
@@ -41,7 +40,6 @@ export default function UploadKidProfile({ route, navigation }) {
 
   const [addKidCircle, { data }] = useMutation(ADD_KIDCIRCLE);
 
-
   // asks permission from used to use camera
   useEffect(() => {
     (async () => {
@@ -65,6 +63,7 @@ export default function UploadKidProfile({ route, navigation }) {
         profileImageUrl: picture,
       },
     });
+    navigation.navigate("Recommended");
   }
   //using camera
   useEffect(() => {
@@ -85,14 +84,12 @@ export default function UploadKidProfile({ route, navigation }) {
 
     console.log(result);
 
-
     if (!result.cancelled) {
       console.log("pickPhoto result.uri", result);
       uploadImage(result.uri, "profile");
       setPicture(result.uri);
     }
   };
-
 
   //upload image to firebase
   const uploadImage = async (uri, imageName) => {
@@ -150,7 +147,6 @@ export default function UploadKidProfile({ route, navigation }) {
     return <Text>No access to camera</Text>;
   }
 
-
   return (
     <View style={[styles.fontFamily]}>
       <View>
@@ -162,7 +158,6 @@ export default function UploadKidProfile({ route, navigation }) {
       <View>
         <Text style={[style.label, style.align, style.spacing]}>
           {`Please upload a profile picture of ${route.params.kidName} for your family.`}
-
         </Text>
       </View>
 
@@ -180,25 +175,19 @@ export default function UploadKidProfile({ route, navigation }) {
           <Button title="Pick a photo" onPress={pickPhoto} />
           <Button
             title="Take Picture"
-
             onPress={() => navigation.navigate("TakeProfilePicture")}
-
           />
         </View>
       </View>
 
       <View style={[{ flexDirection: "row" }, style.spacing]}>
         <View style={[style.button, styles.yellow]}>
-          <TouchableOpacity
-            onPress={() => navigation.navigate("UploadKidProfile")}
-          >
+          <TouchableOpacity onPress={() => navigation.navigate("Recommended")}>
             <Text style={style.button}>Skip this</Text>
           </TouchableOpacity>
         </View>
         <View style={[style.button, styles.dkPink]}>
-
           <TouchableOpacity onPress={onSubmitHandler}>
-
             <Text style={style.button}>Continue</Text>
           </TouchableOpacity>
         </View>

--- a/App/styles/index.js
+++ b/App/styles/index.js
@@ -214,7 +214,7 @@ export default StyleSheet.create({
 
   peekabondLogo: {
     resizeMode: "contain",
-    width: "50%",
+    width: "30%",
     alignSelf: "center",
     marginBottom: -30,
   },

--- a/App/styles/index.js
+++ b/App/styles/index.js
@@ -12,6 +12,7 @@ export default StyleSheet.create({
     textAlign: "center",
     marginTop: "20%",
     marginBottom: "5%",
+    marginHorizontal: "5%",
   },
   titlePassword: {
     fontSize: adjust(22),


### PR DESCRIPTION
- changed the styling of the kidCircle screen
- hardcoded the "kidsCircles" that user has added for now.
- pass this hardcoded data to the KidCircleCard component, which is then rendered inside flatlist.
- the buttons to join or create a family are at the bottom of the flatlist (so scroll past all the kids).
- the NavButtons can receive prop screen="Single", so it doesn't show the other 2 buttons (Recommended/LoveBank) -> It will then go to settings page not showing any NavButtons at the bottom (since it's not needed then.)